### PR TITLE
Fix curl command line to download bash-powerline.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Powerline for Bash in pure Bash script.
 
 Download the Bash script
 
-    curl https://raw.github.com/riobard/bash-powerline/master/bash-powerline.sh > ~/.bash-powerline.sh
+    curl https://raw.githubusercontent.com/riobard/bash-powerline/master/bash-powerline.sh > ~/.bash-powerline.sh
 
 And source it in your `.bashrc`
 


### PR DESCRIPTION
The curl command line was outdated :)
